### PR TITLE
Fix typo in "pipelined" in several places

### DIFF
--- a/about/zipcpu.html
+++ b/about/zipcpu.html
@@ -116,7 +116,7 @@ I/O</a> across a common
     <p>A <a href="https://en.wikipedia.org/wiki/Von_Neumann_architecture">Von-Neumann architecture</a>.  Both instructions and data share a common bus</p>
   </li>
   <li>
-    <p>A <a href="https://en.wikipedia.org/wiki/Pipline_(computing)">pipelind architecture</a>,
+    <p>A <a href="https://en.wikipedia.org/wiki/Pipeline_(computing)">pipelined architecture</a>,
 having stages for <em>prefetch</em>, <em>decode</em>, <em>read-operand</em>, <em>execute</em>, and
 <em>write-back</em>.  The <em>execute</em> stage is implemented by one of
 four blocks: an <a href="https://github.com/ZipCPU/zipcpu/blob/master/rtl/core/cpuops.v">arithmetic logic unit

--- a/blog/2018/01/22/formal-progress.html
+++ b/blog/2018/01/22/formal-progress.html
@@ -179,7 +179,7 @@ the component or not.</p>
     <tr>
       <td> </td>
       <td><a href="https://github.com/ZipCPU/zipcpu/blob/master/rtl/core/dblfetch.v">dblfetch</a></td>
-      <td>Two Insn Pipelind Prefetch</td>
+      <td>Two Insn Pipelined Prefetch</td>
       <td><em>Proven</em></td>
     </tr>
     <tr>
@@ -209,7 +209,7 @@ the component or not.</p>
     <tr>
       <td> </td>
       <td><a href="https://github.com/ZipCPU/zipcpu/blob/master/rtl/core/pipemem.v">pipemem</a></td>
-      <td>Memory Module, supporting pipelind mem access</td>
+      <td>Memory Module, supporting pipelined mem access</td>
       <td><em>Proven</em></td>
     </tr>
     <tr>


### PR DESCRIPTION
I noticed a typo and a broken link while browsing the page and fixed it.